### PR TITLE
Fix: Clean up window resize listener on destroy

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -415,8 +415,9 @@ export class WaveformPlayer {
         // Canvas interactions
         this.canvas.addEventListener('click', (e) => this.handleCanvasClick(e));
 
-        // Window resize
-        window.addEventListener('resize', debounce(() => this.resizeCanvas(), 100));
+        // Window resize - store handler for cleanup
+        this.resizeHandler = debounce(() => this.resizeCanvas(), 100);
+        window.addEventListener('resize', this.resizeHandler);
     }
 
     /**
@@ -627,6 +628,11 @@ export class WaveformPlayer {
      * @private
      */
     resizeCanvas() {
+        // Guard against calls after destruction
+        if (!this.canvas || this.isDestroying) {
+            return;
+        }
+
         const dpr = window.devicePixelRatio || 1;
         const rect = this.canvas.getBoundingClientRect();
 
@@ -1031,6 +1037,12 @@ export class WaveformPlayer {
         if (this.resizeObserver) {
             this.resizeObserver.disconnect();
             this.resizeObserver = null;
+        }
+
+        // Remove window resize listener
+        if (this.resizeHandler) {
+            window.removeEventListener('resize', this.resizeHandler);
+            this.resizeHandler = null;
         }
 
         // Remove from instances map


### PR DESCRIPTION
## Summary
Fixes #1 - the `Cannot read properties of null (reading 'getBoundingClientRect')` error.

## The Problem
The error occurred because:
1. A debounced window resize listener was added in `setupEventListeners()` but never removed in `destroy()`
2. `resizeCanvas()` didn't guard against being called after destruction

When the debounced callback fired after the player was destroyed, `this.canvas` was already null, causing the error.

## The Fix
- Store the resize handler reference so it can be removed later
- Remove the window resize listener in `destroy()`
- Add a guard in `resizeCanvas()` to bail early if `canvas` is null or `isDestroying` is true