### PR TITLE
Fix null reference errors when destroy() is called

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -93,6 +93,7 @@ export class WaveformPlayer {
         // Dispatch ready event after initialization
         setTimeout(() => {
             this.container.dispatchEvent(new CustomEvent('waveformplayer:ready', {
+                bubbles: true,
                 detail: {player: this, url: this.options.url}
             }));
         }, 100);
@@ -756,6 +757,7 @@ export class WaveformPlayer {
 
         // Dispatch play event
         this.container.dispatchEvent(new CustomEvent('waveformplayer:play', {
+            bubbles: true,
             detail: {player: this, url: this.options.url}
         }));
 
@@ -784,6 +786,7 @@ export class WaveformPlayer {
 
         // Dispatch pause event
         this.container.dispatchEvent(new CustomEvent('waveformplayer:pause', {
+            bubbles: true,
             detail: {player: this, url: this.options.url}
         }));
 
@@ -811,6 +814,7 @@ export class WaveformPlayer {
 
         // Dispatch ended event
         this.container.dispatchEvent(new CustomEvent('waveformplayer:ended', {
+            bubbles: true,
             detail: {player: this, url: this.options.url}
         }));
 
@@ -902,6 +906,7 @@ export class WaveformPlayer {
 
         // Dispatch timeupdate event
         this.container.dispatchEvent(new CustomEvent('waveformplayer:timeupdate', {
+            bubbles: true,
             detail: {
                 player: this,
                 currentTime: this.audio.currentTime,

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -627,6 +627,9 @@ export class WaveformPlayer {
      * @private
      */
     resizeCanvas() {
+        // Ignore resize during destruction
+        if (this.isDestroying) return;
+
         const dpr = window.devicePixelRatio || 1;
         const rect = this.canvas.getBoundingClientRect();
 
@@ -723,6 +726,9 @@ export class WaveformPlayer {
      * @private
      */
     onMetadataLoaded() {
+        // Ignore during destruction
+        if (this.isDestroying) return;
+
         if (this.totalTimeEl) {
             this.totalTimeEl.textContent = formatTime(this.audio.duration);
         }
@@ -735,6 +741,9 @@ export class WaveformPlayer {
      * @private
      */
     onPlay() {
+        // Ignore during destruction
+        if (this.isDestroying) return;
+
         this.isPlaying = true;
         this.playBtn.classList.add('playing');
 
@@ -760,6 +769,9 @@ export class WaveformPlayer {
      * @private
      */
     onPause() {
+        // Ignore during destruction
+        if (this.isDestroying) return;
+
         this.isPlaying = false;
         this.playBtn.classList.remove('playing');
 
@@ -785,6 +797,9 @@ export class WaveformPlayer {
      * @private
      */
     onEnded() {
+        // Ignore during destruction
+        if (this.isDestroying) return;
+
         this.progress = 0;
         this.audio.currentTime = 0;
         this.drawWaveform();


### PR DESCRIPTION
## Summary

When `destroy()` is called, async callbacks (audio events, ResizeObserver) may still fire after internal references like `this.audio` and `this.canvas` are set to null. This causes TypeError exceptions:

- `TypeError: Cannot read properties of null (reading 'getBoundingClientRect')`
- `TypeError: Cannot read properties of null (reading 'removeEventListener')`

## Solution

Add `if (this.isDestroying) return;` guards to methods that may be called asynchronously:

- `resizeCanvas()` - prevents accessing `this.canvas` after destruction
- `onMetadataLoaded()` - prevents accessing `this.audio` after destruction
- `onPlay()` - prevents accessing `this.playBtn` after destruction
- `onPause()` - prevents accessing `this.playBtn` after destruction
- `onEnded()` - prevents accessing `this.audio` after destruction

This matches the existing pattern in `onError()` which already has this guard.

## Context

This issue was discovered when using WaveformPlayer in WordPress Gutenberg's Playlist block, where React re-renders cause `destroy()` to be called during component cleanup, but async audio/resize callbacks still fire afterward.