### PR TITLE
Return promise from play() method

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -938,6 +938,7 @@ export class WaveformPlayer {
 
     /**
      * Play audio
+     * @return {Promise} The promise returned by HTMLMediaElement.play()
      */
     play() {
         if (this.options.singlePlay && WaveformPlayer.currentlyPlaying &&
@@ -946,7 +947,7 @@ export class WaveformPlayer {
         }
 
         WaveformPlayer.currentlyPlaying = this;
-        this.audio.play();
+        return this.audio.play();
     }
 
     /**


### PR DESCRIPTION
The play() method calls this.audio.play() which returns a Promise, but the return value was being discarded. This prevents callers from handling errors like AbortError (thrown when play is interrupted by pause or a new track load).