### PR TITLE
Fix: add waveform-is-placeholder class to container on analysis failure

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1150,6 +1150,7 @@ export class WaveformPlayer {
             this.setLoading(true);
             this.progress = 0;
             this.hasError = false;
+            this.container.classList.remove('waveform-is-placeholder');
 
             // In external mode we don't own an <audio> element — skip
             // src assignment + metadata-wait, but still generate the
@@ -1202,6 +1203,7 @@ export class WaveformPlayer {
                 } catch (error) {
                     console.warn('[WaveformPlayer] Using placeholder waveform:', error);
                     this.waveformData = generatePlaceholderWaveform(this.options.samples);
+                    this.container.classList.add('waveform-is-placeholder');
                 }
             }
 

--- a/test/player.test.js
+++ b/test/player.test.js
@@ -1003,3 +1003,25 @@ describe('speed menu a11y (#11)', () => {
 		expect(btn.getAttribute('aria-expanded')).toBe('true');
 	});
 });
+
+describe('waveform analysis fallback', () => {
+	it('adds the waveform-is-placeholder class on analysis failure', async () => {
+		const { el, player } = track(mount());
+		await player.loadTrack('does-not-exist.mp3', null, null, { autoplay: false });
+		expect(el.classList.contains('waveform-is-placeholder')).toBe(true);
+	});
+
+	it('removes the waveform-is-placeholder class when a new load starts', async () => {
+		const { el, player } = track(mount());
+		await player.loadTrack('does-not-exist.mp3', null, null, { autoplay: false });
+		expect(el.classList.contains('waveform-is-placeholder')).toBe(true);
+
+		const loadPromise = player.loadTrack('next.mp3', 'Next', 'Artist', {
+			waveform: [0.1, 0.5, 0.9],
+			autoplay: false
+		});
+		expect(el.classList.contains('waveform-is-placeholder')).toBe(false);
+		await loadPromise;
+	});
+});
+


### PR DESCRIPTION
Closes #19 

### Summary
This PR adds a CSS state class `waveform-is-placeholder` to the player container when the waveform generation fails and falls back to placeholder peaks (such as on CORS blocked tracks).

### Details
- Removes the `.waveform-is-placeholder` class at the start of `load()` to reset the player state when loading new tracks.
- Adds the `.waveform-is-placeholder` class inside the `load()` catch block when analysis fails.
- Adds unit tests in `test/player.test.js` to verify class toggling on load and failure.

### Why this is needed
This class allows integrating applications (such as the WordPress Gutenberg editor) to identify when a decorative waveform is being shown and conditionally restyle it (e.g. flat-lining it to look like a standard progress bar instead of displaying randomised audio peaks).

### Use of AI Tools
AI assistance: Yes
Tool(s): Antigravity IDE
Model(s): Gemini 3.5 Flash (Low)
Used for: Help in identifying and locating the relevant code lines to fix, approach of fixing. Tests were implemented via it. Final implementation was reviewed and tested by me. 
